### PR TITLE
Crée des pages dédiées et personnalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Ce projet propose une petite application sans dépendances externes permettant :
 - la création d'un compte (un seul compte par adresse IP)
 - la connexion/déconnexion
 - la modification d'une page de biographie
+- la personnalisation des couleurs de sa page
 
 ## Utilisation
 
@@ -13,5 +14,6 @@ Ce projet propose une petite application sans dépendances externes permettant :
    node server.js
    ```
 2. Ouvrez votre navigateur à l'adresse [http://localhost:3000](http://localhost:3000)
-
 Toutes les données sont enregistrées dans `db.json` à la racine du projet.
+
+Les pages principales sont : /login, /register, /dashboard, /customise et /<nom_utilisateur>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,56 @@
+body {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(135deg, #282c34, #3b3f47);
+  color: #f0f0f0;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  background: rgba(0, 0, 0, 0.6);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  width: 90%;
+  max-width: 500px;
+}
+
+h1 {
+  text-align: center;
+  margin-top: 0;
+}
+
+form {
+  margin-bottom: 2rem;
+}
+
+input[type="text"],
+input[type="password"],
+textarea {
+  width: 100%;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+  border-radius: 4px;
+  border: none;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background: #61dafb;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+a {
+  color: #61dafb;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+}


### PR DESCRIPTION
## Summary
- refactor home page to link to login/register
- create standalone Connexion and Register pages
- add dashboard navigation and a customise page
- allow users to choose colors for their bio page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889e6dd4900832586bd29394e1af0f9