### PR TITLE
Crée des pages dédiées et personnalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Ce projet propose une petite application sans dépendances externes permettant :
 - la création d'un compte (un seul compte par adresse IP)
 - la connexion/déconnexion
 - la modification d'une page de biographie
+- la personnalisation des couleurs de sa page
+- l'ajout d'une bannière en téléversant une image
 
 ## Utilisation
 
@@ -13,5 +15,7 @@ Ce projet propose une petite application sans dépendances externes permettant :
    node server.js
    ```
 2. Ouvrez votre navigateur à l'adresse [http://localhost:3000](http://localhost:3000)
-
 Toutes les données sont enregistrées dans `db.json` à la racine du projet.
+
+Les pages principales sont : /login, /register, /dashboard, /customise et /<nom_utilisateur>
+La page `/customise` permet maintenant de choisir les couleurs et de téléverser une bannière qui s'affichera en haut de votre bio.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,29 @@ const fs = require('fs');
 const crypto = require('crypto');
 const { URL } = require('url');
 const qs = require('querystring');
+const pathModule = require('path');
+
+function parseMultipart(body, boundary) {
+  const result = {};
+  const parts = body.split('--' + boundary);
+  parts.forEach(part => {
+    if (!part || part === '--\r\n') return;
+    const nameMatch = part.match(/name="([^"]+)"/);
+    if (!nameMatch) return;
+    const name = nameMatch[1];
+    const filenameMatch = part.match(/filename="([^"]*)"/);
+    const dataStart = part.indexOf('\r\n\r\n');
+    if (dataStart === -1) return;
+    let value = part.slice(dataStart + 4);
+    value = value.replace(/\r\n$/, '');
+    if (filenameMatch && filenameMatch[1]) {
+      result[name] = { filename: filenameMatch[1], content: value };
+    } else {
+      result[name] = value;
+    }
+  });
+  return result;
+}
 
 const PORT = 3000;
 const DB_FILE = 'db.json';
@@ -45,23 +68,62 @@ function parseCookies(cookieHeader) {
 function handleHome(req, res, username) {
   const html = `<!DOCTYPE html>
 <html lang="fr">
-<head><meta charset="UTF-8"><title>Site de Bios</title></head>
+<head>
+<meta charset="UTF-8">
+<title>Site de Bios</title>
+<link rel="stylesheet" href="/styles.css">
+</head>
 <body>
-<h1>Site de Bios</h1>
-${username ? `<p>Bonjour ${username} | <a href="/logout">Déconnexion</a> | <a href="/dashboard">Gérer ma bio</a></p>` : `
-<h2>Connexion</h2>
-<form method="POST" action="/login">
-<input name="username" placeholder="Nom d'utilisateur"><br>
-<input type="password" name="password" placeholder="Mot de passe"><br>
-<button type="submit">Se connecter</button>
-</form>
-<h2>Inscription</h2>
-<form method="POST" action="/register">
-<input name="username" placeholder="Nom d'utilisateur"><br>
-<input type="password" name="password" placeholder="Mot de passe"><br>
-<button type="submit">Créer un compte</button>
-</form>
-`}
+  <div class="container">
+    <h1>Site de Bios</h1>
+    ${username ? `<p>Bonjour ${username} | <a href="/dashboard">Dashboard</a> | <a href="/customise">Customise</a> | <a href="/logout">Déconnexion</a></p>` : `<p><a href="/login">Connexion</a> | <a href="/register">Créer un compte</a></p>`}
+  </div>
+</body></html>`;
+  send(res, 200, html);
+}
+
+function handleLoginPage(req, res) {
+  const html = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Connexion</title>
+<link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Connexion</h1>
+    <form method="POST" action="/login">
+      <input name="username" placeholder="Nom d'utilisateur" required>
+      <input type="password" name="password" placeholder="Mot de passe" required>
+      <div class="actions"><button type="submit">Se connecter</button></div>
+    </form>
+    <p><a href="/register">Créer un compte</a></p>
+    <p><a href="/">Accueil</a></p>
+  </div>
+</body></html>`;
+  send(res, 200, html);
+}
+
+function handleRegisterPage(req, res) {
+  const html = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Inscription</title>
+<link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Inscription</h1>
+    <form method="POST" action="/register">
+      <input name="username" placeholder="Nom d'utilisateur" required>
+      <input type="password" name="password" placeholder="Mot de passe" required>
+      <div class="actions"><button type="submit">Créer un compte</button></div>
+    </form>
+    <p><a href="/login">Connexion</a></p>
+    <p><a href="/">Accueil</a></p>
+  </div>
 </body></html>`;
   send(res, 200, html);
 }
@@ -85,7 +147,11 @@ function handleRegister(req, res) {
       return;
     }
     const hash = crypto.createHash('sha256').update(data.password).digest('hex');
-    db.users[data.username] = { password: hash, bio: 'Nouvelle bio' };
+    db.users[data.username] = {
+      password: hash,
+      bio: 'Nouvelle bio',
+      style: { bgColor: '#000000', textColor: '#f0f0f0' }
+    };
     db.ipToUser[ip] = data.username;
     saveDb();
     res.writeHead(302, { Location: '/' });
@@ -137,14 +203,20 @@ function handleDashboard(req, res, username) {
   const bio = db.users[username].bio || '';
   const html = `<!DOCTYPE html>
 <html lang="fr">
-<head><meta charset="UTF-8"><title>Mon compte</title></head>
+<head>
+<meta charset="UTF-8">
+<title>Mon compte</title>
+<link rel="stylesheet" href="/styles.css">
+</head>
 <body>
-<h1>Mon Compte</h1>
-<p><a href="/">Accueil</a> | <a href="/logout">Déconnexion</a></p>
-<form method="POST" action="/update">
-<textarea name="bio" rows="5" cols="40">${bio}</textarea><br>
-<button type="submit">Mettre à jour</button>
-</form>
+  <div class="container">
+    <h1>Mon Compte</h1>
+    <p><a href="/">Accueil</a> | <a href="/customise">Personnaliser</a> | <a href="/logout">Déconnexion</a></p>
+    <form method="POST" action="/update">
+      <textarea name="bio" rows="5" cols="40">${bio}</textarea>
+      <div class="actions"><button type="submit">Mettre à jour</button></div>
+    </form>
+  </div>
 </body></html>`;
   send(res, 200, html);
 }
@@ -161,19 +233,88 @@ function handleUpdate(req, res, username) {
   });
 }
 
+function handleCustomisePage(req, res, username) {
+  const user = db.users[username];
+  const style = user.style || { bgColor: '#000000', textColor: '#f0f0f0' };
+  const html = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Customise</title>
+<link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Personnaliser</h1>
+    ${style.banner ? `<div class="banner" style="background-image:url('${style.banner}')"></div>` : ''}
+    <form method="POST" action="/customise" enctype="multipart/form-data">
+      <label>Couleur de fond</label>
+      <input type="color" name="bgColor" value="${style.bgColor}">
+      <label>Couleur du texte</label>
+      <input type="color" name="textColor" value="${style.textColor}">
+      <label>Bannière</label>
+      <input type="file" name="banner">
+      <div class="actions"><button type="submit">Enregistrer</button></div>
+    </form>
+    <p><a href="/dashboard">Retour</a></p>
+  </div>
+</body></html>`;
+  send(res, 200, html);
+}
+
+function handleCustomiseUpdate(req, res, username) {
+  const chunks = [];
+  req.on('data', chunk => chunks.push(chunk));
+  req.on('end', () => {
+    const contentType = req.headers['content-type'] || '';
+    let data = {};
+    if (contentType.startsWith('multipart/form-data')) {
+      const boundary = contentType.split('boundary=')[1];
+      const body = Buffer.concat(chunks).toString('binary');
+      data = parseMultipart(body, boundary);
+    } else {
+      const body = Buffer.concat(chunks).toString();
+      data = qs.parse(body);
+    }
+    const userStyle = db.users[username].style || { bgColor: '#000000', textColor: '#f0f0f0' };
+    userStyle.bgColor = data.bgColor || userStyle.bgColor || '#000000';
+    userStyle.textColor = data.textColor || userStyle.textColor || '#f0f0f0';
+    if (data.banner && data.banner.filename) {
+      const ext = pathModule.extname(data.banner.filename) || '';
+      const fileName = username + '_banner' + ext;
+      const filePath = pathModule.join(__dirname, 'uploads', fileName);
+      fs.writeFileSync(filePath, data.banner.content, 'binary');
+      userStyle.banner = '/uploads/' + fileName;
+    }
+    db.users[username].style = userStyle;
+    saveDb();
+    res.writeHead(302, { Location: '/customise' });
+    res.end();
+  });
+}
+
 function handleUserPage(req, res, username) {
   const user = db.users[username];
   if (!user) {
     send(res, 404, 'Page non trouvée');
     return;
   }
+  const style = user.style || { bgColor: '#000000', textColor: '#f0f0f0' };
   const html = `<!DOCTYPE html>
 <html lang="fr">
-<head><meta charset="UTF-8"><title>${username}</title></head>
+<head>
+<meta charset="UTF-8">
+<title>${username}</title>
+<link rel="stylesheet" href="/styles.css">
+<style>body{background:${style.bgColor};color:${style.textColor};${style.banner ? `background-image:url('${style.banner}');background-size:cover;background-position:center;` : ''}}</style>
+</head>
 <body>
-<h1>${username}</h1>
-<p>${user.bio}</p>
-<p><a href="/">Accueil</a></p>
+  <div class="container">
+    ${style.banner ? `<div class="banner" style="background-image:url('${style.banner}')"></div>` : ''}
+    <h1>${username}</h1>
+    <p>${user.bio}</p>
+    <p><a href="/">Accueil</a></p>
+  </div>
 </body></html>`;
   send(res, 200, html);
 }
@@ -187,6 +328,28 @@ function onRequest(req, res) {
 
   if (path === '/' && req.method === 'GET') {
     handleHome(req, res, username);
+  } else if (path === '/styles.css' && req.method === 'GET') {
+    fs.readFile(pathModule.join(__dirname, 'styles.css'), (err, data) => {
+      if (err) {
+        send(res, 404, 'Not found');
+      } else {
+        send(res, 200, data, 'text/css');
+      }
+    });
+  } else if (path.startsWith('/uploads/') && req.method === 'GET') {
+    const filePath = pathModule.join(__dirname, path.replace(/^\//, ''));
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        send(res, 404, 'Not found');
+      } else {
+        const type = 'image/' + pathModule.extname(filePath).slice(1);
+        send(res, 200, data, type);
+      }
+    });
+  } else if (path === '/login' && req.method === 'GET') {
+    handleLoginPage(req, res);
+  } else if (path === '/register' && req.method === 'GET') {
+    handleRegisterPage(req, res);
   } else if (path === '/register' && req.method === 'POST') {
     handleRegister(req, res);
   } else if (path === '/login' && req.method === 'POST') {
@@ -196,6 +359,12 @@ function onRequest(req, res) {
   } else if (path === '/dashboard') {
     const user = requireLogin(req, res, sessionId);
     if (user) handleDashboard(req, res, user);
+  } else if (path === '/customise' && req.method === 'GET') {
+    const user = requireLogin(req, res, sessionId);
+    if (user) handleCustomisePage(req, res, user);
+  } else if (path === '/customise' && req.method === 'POST') {
+    const user = requireLogin(req, res, sessionId);
+    if (user) handleCustomiseUpdate(req, res, user);
   } else if (path === '/update' && req.method === 'POST') {
     const user = requireLogin(req, res, sessionId);
     if (user) handleUpdate(req, res, user);
@@ -207,6 +376,9 @@ function onRequest(req, res) {
 }
 
 loadDb();
+if (!fs.existsSync(pathModule.join(__dirname, 'uploads'))) {
+  fs.mkdirSync(pathModule.join(__dirname, 'uploads'));
+}
 http.createServer(onRequest).listen(PORT, () => {
   console.log('Server running on http://localhost:' + PORT);
 });

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,71 @@
+body {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(135deg, #282c34, #3b3f47);
+  color: #f0f0f0;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  background: rgba(0, 0, 0, 0.6);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  width: 90%;
+  max-width: 500px;
+}
+
+h1 {
+  text-align: center;
+  margin-top: 0;
+}
+
+form {
+  margin-bottom: 2rem;
+}
+
+input[type="text"],
+input[type="password"],
+textarea {
+  width: 100%;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+  border-radius: 4px;
+  border: none;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background: #61dafb;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+a {
+  color: #61dafb;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.container img {
+  max-width: 100%;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.banner {
+  width: 100%;
+  height: 150px;
+  background-size: cover;
+  background-position: center;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- refactor home page to link to login/register
- create standalone Connexion and Register pages
- add dashboard navigation and a customise page
- allow users to choose colors for their bio page
- add ability to upload a banner image for profiles
- show uploaded banners as page backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889e6dd4900832586bd29394e1af0f9